### PR TITLE
viteconfigにbaseを追加

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -3,4 +3,5 @@ import vue from '@vitejs/plugin-vue';
 
 export default defineConfig({
   plugins: [vue()],
+  base: './', // ここを追加して相対パスに設定
 });


### PR DESCRIPTION
baseを相対パスにしていなかったため、```bun run build```実行時に絶対パスが指定されてしまい、ページをうまく表示できなかった。